### PR TITLE
fix(docs): update homebrew installation command for macOS

### DIFF
--- a/src/content/docs/install/mac.mdx
+++ b/src/content/docs/install/mac.mdx
@@ -10,5 +10,5 @@ import { LinkButton } from "@astrojs/starlight/components";
 Advanced users can install Vesktop via homebrew:
 
 ```bash
-brew install --cask vesktop
+brew install vesktop
 ```

--- a/src/content/docs/install/mac.mdx
+++ b/src/content/docs/install/mac.mdx
@@ -10,5 +10,5 @@ import { LinkButton } from "@astrojs/starlight/components";
 Advanced users can install Vesktop via homebrew:
 
 ```bash
-brew install vesktop
+brew install --cask vesktop
 ```


### PR DESCRIPTION
* Changed installation command to use --cask for Vesktop
* Ensures correct installation method for users