### PR TITLE
Update Vesktop instructions for Wayland

### DIFF
--- a/src/content/docs/wiki/linux/tips.mdx
+++ b/src/content/docs/wiki/linux/tips.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## Run in XWayland mode
 
-Vesktop runs as a Wayland application by default on Wayland environments. You can override this behaviour.
+Vesktop runs as a Wayland application by default on Wayland sessions. You can override this behaviour.
 
 -   If you are using Flatpak, open [Flatseal](https://flathub.org/en/apps/com.github.tchx84.Flatseal) and deny the `Wayland windowing system` permission for Vesktop.
 -   If you are not using Flatpak, you can opt into X11 by running vesktop with the `--ozone-platform=x11` flag. To make this permanent, see [Making Command line flags permanent](#making-command-line-flags-permanent).

--- a/src/content/docs/wiki/linux/tips.mdx
+++ b/src/content/docs/wiki/linux/tips.mdx
@@ -5,12 +5,12 @@ sidebar:
     order: 1
 ---
 
-## Wayland Support
+## Run in XWayland mode
 
-Vesktop runs as an X11 application by default. You can override this behaviour.
+Vesktop runs as a Wayland application by default on Wayland environments. You can override this behaviour.
 
--   If you are using Flatpak, open [Flatseal](https://flathub.org/en/apps/com.github.tchx84.Flatseal) and deny the `X11 windowing system` permission for Vesktop.
--   If you are not using Flatpak, you can opt into Wayland by running vesktop with the `--ozone-platform-hint=auto` flag. To make this permanent, see [Making Command line flags permanent](#making-command-line-flags-permanent).
+-   If you are using Flatpak, open [Flatseal](https://flathub.org/en/apps/com.github.tchx84.Flatseal) and deny the `Wayland windowing system` permission for Vesktop.
+-   If you are not using Flatpak, you can opt into X11 by running vesktop with the `--ozone-platform=x11` flag. To make this permanent, see [Making Command line flags permanent](#making-command-line-flags-permanent).
 
 ## GNOME Tray Icon
 
@@ -29,7 +29,7 @@ It should usually be in `/usr/share/applications/vesktop.desktop`.
 Open it with a text editor and add your flags to the `Exec` line, after the binary path and before the `%U` (if it exists).
 
 ```
-Exec=/usr/bin/vesktop --ozone-platform-hint=auto %U
+Exec=/usr/bin/vesktop --ozone-platform=x11 %U
 ```
 
 ## Enable Middle Click Auto Scroll

--- a/src/content/docs/wiki/linux/tips.mdx
+++ b/src/content/docs/wiki/linux/tips.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 Vesktop runs as a Wayland application by default on Wayland sessions. You can override this behaviour.
 
--   If you are using Flatpak, open [Flatseal](https://flathub.org/en/apps/com.github.tchx84.Flatseal) and deny the `Wayland windowing system` permission for Vesktop.
+-   If you are using Flatpak, open [Flatseal](https://flathub.org/en/apps/com.github.tchx84.Flatseal) , scroll to "Environment" and add the variable `XDG_SESSION_TYPE=x11`.
 -   If you are not using Flatpak, you can opt into X11 by running vesktop with the `--ozone-platform=x11` flag. To make this permanent, see [Making Command line flags permanent](#making-command-line-flags-permanent).
 
 ## GNOME Tray Icon


### PR DESCRIPTION
Replaced the instructions to run Vesktop as a Wayland application for instructions to run Vesktop in XWayland mode.

Since [Electron 38](https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-380), it now "defaults to running as a native Wayland app when launched in a Wayland session". Users that might have a problem with this changed might want to force Vesktop to run in XWayland mode.

Closes #6 