### PR TITLE
add Vesktop-bin to list of Arch installation options.

### DIFF
--- a/src/content/docs/install/linux.mdx
+++ b/src/content/docs/install/linux.mdx
@@ -50,6 +50,7 @@ Download the right rpm package and double click it to install.
 
 <LinkButton href="https://aur.archlinux.org/packages/vesktop">vesktop</LinkButton>
 <LinkButton href="https://aur.archlinux.org/packages/vesktop-git">vesktop-git</LinkButton>
+<LinkButton href="https://aur.archlinux.org/packages/vesktop-bin">vesktop-bin</LinkButton>
 
 <IconHeader tag="h4" iconUrl={AppImageIcon.src}>
     AppImage (Universal)


### PR DESCRIPTION
Apologies if this is incorrect.